### PR TITLE
Improve `Client::from_env`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,16 +276,12 @@ impl Client {
     /// `Some` of the connected client will be returned. If no jobserver was
     /// found then `None` will be returned.
     ///
-    /// Note that on Unix the `Client` returned **takes ownership of the file
-    /// descriptors specified in the environment**. Jobservers on Unix are
-    /// implemented with `pipe` file descriptors, and they're inherited from
-    /// parent processes. This `Client` returned takes ownership of the file
-    /// descriptors for this process and will close the file descriptors after
-    /// this value is dropped.
-    ///
-    /// Additionally on Unix this function will configure the file descriptors
+    /// Note that on Unix  this function will configure the file descriptors
     /// with `CLOEXEC` so they're not automatically inherited by spawned
     /// children.
+    ///
+    /// Jobservers on Unix are implemented with `pipe` file descriptors,
+    /// and they're inherited from parent processes.
     ///
     /// # Safety
     ///
@@ -297,9 +293,6 @@ impl Client {
     /// program before any other file descriptors are opened. That way you can
     /// make sure to take ownership properly of the file descriptors passed
     /// down, if any.
-    ///
-    /// It's generally unsafe to call this function twice in a program if the
-    /// previous invocation returned `Some`.
     ///
     /// Note, though, that on Windows it should be safe to call this function
     /// any number of times.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,8 +267,8 @@ impl Client {
     ///
     /// Note that the created `Client` is not automatically inherited into
     /// spawned child processes from this program. Manual usage of the
-    /// `configure` function is required for a child process to have access to a
-    /// job server.
+    /// [`Client::configure_and_run`] or [`Client::configure_make_and_run`]
+    /// function is required for a child process to have access to a job server.
     ///
     /// # Return value
     ///

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -89,6 +89,9 @@ impl Client {
         // then we'll have `MAKEFLAGS` env vars but won't actually have
         // access to the file descriptors.
         if is_pipe(read, true) && is_pipe(write, false) {
+            let read = dup(read).ok()?;
+            let write = dup(write).ok()?;
+
             drop(set_cloexec(read, true));
             drop(set_nonblocking(read, false));
 
@@ -295,6 +298,10 @@ fn set_nonblocking(fd: c_int, set: bool) -> io::Result<()> {
     }
 
     Ok(())
+}
+
+fn dup(fd: c_int) -> io::Result<c_int> {
+    cvt(unsafe { libc::dup(fd) })
 }
 
 fn cvt(t: c_int) -> io::Result<c_int> {


### PR DESCRIPTION
 - [Make it safe to call Client::from_env twice on unix](https://github.com/cargo-bins/jobslot/commit/9a5ebc3f6a102b1e2af77ac8f1589948d0f5f3d0)

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>