### PR TITLE
Add `available` traits to find out how many client tokens are unused

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,6 +347,19 @@ impl Client {
         Ok(Acquired::new(self, data))
     }
 
+    /// Returns amount of tokens in the read-side pipe.
+    ///
+    /// # Return value
+    ///
+    /// Number of bytes available to be read from the jobserver pipe
+    ///
+    /// # Errors
+    ///
+    /// Underlying errors from the ioctl will be passed up.
+    pub fn available(&self) -> io::Result<usize> {
+        self.inner.available()
+    }
+
     /// Configures a child process to have access to this client's jobserver as
     /// well and run the `f` which spawns the process.
     ///

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -169,6 +169,12 @@ impl Client {
 
         unsafe { cmd.pre_exec(f) };
     }
+
+    pub fn available(&self) -> io::Result<usize> {
+        let mut len = MaybeUninit::<c_int>::uninit();
+        cvt(unsafe { libc::ioctl(self.read.as_raw_fd(), libc::FIONREAD, len.as_mut_ptr()) })?;
+        Ok(unsafe { len.assume_init() } as usize)
+    }
 }
 
 #[derive(Debug)]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -173,7 +173,7 @@ impl Client {
     pub fn available(&self) -> io::Result<usize> {
         let mut len = MaybeUninit::<c_int>::uninit();
         cvt(unsafe { libc::ioctl(self.read.as_raw_fd(), libc::FIONREAD, len.as_mut_ptr()) })?;
-        Ok(unsafe { len.assume_init() } as usize)
+        Ok(unsafe { len.assume_init() }.try_into().unwrap())
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -72,6 +72,11 @@ impl Client {
              so Client::configure_and_run is not supported."
         );
     }
+
+    pub fn available(&self) -> io::Result<usize> {
+        let lock = self.inner.count.lock().unwrap_or_else(|e| e.into_inner());
+        Ok(*lock)
+    }
 }
 
 #[derive(Debug)]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -143,6 +143,26 @@ impl Client {
         // nothing to do here, we gave the name of our semaphore to the
         // child above
     }
+
+    pub fn available(&self) -> io::Result<usize> {
+        // Can't read value of a semaphore on Windows, so
+        // try to acquire without sleeping, since we can find out the
+        // old value on release. If acquisiton fails, then available is 0.
+        unsafe {
+            let r = WaitForSingleObject(self.sem.0, 0);
+            if r != WAIT_OBJECT_0 {
+                Ok(0)
+            } else {
+                let mut prev: LONG = 0;
+                let r = ReleaseSemaphore(self.sem.0, 1, &mut prev);
+                if r != 0 {
+                    Ok(prev as usize + 1)
+                } else {
+                    Err(io::Error::last_os_error())
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -174,7 +174,7 @@ impl Client {
         } else {
             let mut prev = MaybeUninit::uninit();
             self.release_inner(Some(&mut prev))?;
-            // SAFETY: release_inner will initialize it
+            // SAFETY: release_inner has initialize it
             let prev: usize = unsafe { prev.assume_init() }.try_into().unwrap();
             Ok(prev + 1)
         }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -174,7 +174,7 @@ impl Client {
         } else {
             let mut prev = MaybeUninit::uninit();
             self.release_inner(Some(&mut prev))?;
-            // SAFETY: release_inner has initialize it
+            // SAFETY: release_inner has initialized it
             let prev: usize = unsafe { prev.assume_init() }.try_into().unwrap();
             Ok(prev + 1)
         }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -133,10 +133,7 @@ impl Client {
         self.release_inner(None)
     }
 
-    fn release_inner(
-        &self,
-        prev_count: Option<&mut MaybeUninit<LONG>>,
-    ) -> io::Result<Option<LONG>> {
+    fn release_inner(&self, prev_count: Option<&mut MaybeUninit<LONG>>) -> io::Result<()> {
         // SAFETY: ReleaseSemaphore will write to prev_count is it is Some
         // and release semaphore self.sem by 1.
         let r = unsafe {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,6 +4,7 @@ use std::{
     ffi::CString,
     fmt::Write,
     io,
+    mem::MaybeUninit,
     num::NonZeroIsize,
     ptr,
     sync::Arc,
@@ -115,7 +116,12 @@ impl Client {
     }
 
     pub fn acquire(&self) -> io::Result<Acquired> {
-        let r = unsafe { WaitForSingleObject(self.sem.as_raw_handle(), INFINITE) };
+        self.acquire_inner(INFINITE)
+    }
+
+    /// * `timeout` - can be `INFINITE` or 0 or any other number.
+    fn acquire_inner(&self, timeout: u32) -> io::Result<Acquired> {
+        let r = unsafe { WaitForSingleObject(self.sem.as_raw_handle(), timeout) };
         if r == WAIT_OBJECT_0 {
             Ok(Acquired)
         } else {
@@ -124,7 +130,24 @@ impl Client {
     }
 
     pub fn release(&self, _data: Option<&Acquired>) -> io::Result<()> {
-        let r = unsafe { ReleaseSemaphore(self.sem.as_raw_handle(), 1, ptr::null_mut()) };
+        self.release_inner(None)
+    }
+
+    fn release_inner(
+        &self,
+        prev_count: Option<&mut MaybeUninit<LONG>>,
+    ) -> io::Result<Option<LONG>> {
+        // SAFETY: ReleaseSemaphore will write to prev_count is it is Some
+        // and release semaphore self.sem by 1.
+        let r = unsafe {
+            ReleaseSemaphore(
+                self.sem.as_raw_handle(),
+                1,
+                prev_count
+                    .map(MaybeUninit::as_mut_ptr)
+                    .unwrap_or_else(ptr::null_mut),
+            )
+        };
         if r != 0 {
             Ok(())
         } else {
@@ -147,20 +170,16 @@ impl Client {
     pub fn available(&self) -> io::Result<usize> {
         // Can't read value of a semaphore on Windows, so
         // try to acquire without sleeping, since we can find out the
-        // old value on release. If acquisiton fails, then available is 0.
-        unsafe {
-            let r = WaitForSingleObject(self.sem.0, 0);
-            if r != WAIT_OBJECT_0 {
-                Ok(0)
-            } else {
-                let mut prev: LONG = 0;
-                let r = ReleaseSemaphore(self.sem.0, 1, &mut prev);
-                if r != 0 {
-                    Ok(prev as usize + 1)
-                } else {
-                    Err(io::Error::last_os_error())
-                }
-            }
+        // old value on release.
+        if self.acquire_inner(0).is_err() {
+            // If acquisiton fails, then available is 0.
+            Ok(0)
+        } else {
+            let mut prev = MaybeUninit::uninit();
+            self.release_inner(Some(&mut prev))?;
+            // SAFETY: release_inner will initialize it
+            let prev: usize = unsafe { prev.assume_init() }.try_into().unwrap();
+            Ok(prev + 1)
         }
     }
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -25,6 +25,30 @@ fn server_multiple() {
 }
 
 #[test]
+fn server_available() {
+    let c = t!(Client::new(10));
+    assert_eq!(c.available().unwrap(), 10);
+    let a = c.acquire().unwrap();
+    assert_eq!(c.available().unwrap(), 9);
+    drop(a);
+    assert_eq!(c.available().unwrap(), 10);
+}
+
+#[test]
+fn server_none_available() {
+    let c = t!(Client::new(2));
+    assert_eq!(c.available().unwrap(), 2);
+    let a = c.acquire().unwrap();
+    assert_eq!(c.available().unwrap(), 1);
+    let b = c.acquire().unwrap();
+    assert_eq!(c.available().unwrap(), 0);
+    drop(a);
+    assert_eq!(c.available().unwrap(), 1);
+    drop(b);
+    assert_eq!(c.available().unwrap(), 2);
+}
+
+#[test]
 fn server_blocks() {
     let c = Client::new(1).unwrap();
     let a = c.acquire().unwrap();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -26,7 +26,7 @@ fn server_multiple() {
 
 #[test]
 fn server_available() {
-    let c = t!(Client::new(10));
+    let c = Client::new(10).unwrap();
     assert_eq!(c.available().unwrap(), 10);
     let a = c.acquire().unwrap();
     assert_eq!(c.available().unwrap(), 9);
@@ -36,7 +36,7 @@ fn server_available() {
 
 #[test]
 fn server_none_available() {
-    let c = t!(Client::new(2));
+    let c = Client::new(2).unwrap();
     assert_eq!(c.available().unwrap(), 2);
     let a = c.acquire().unwrap();
     assert_eq!(c.available().unwrap(), 1);


### PR DESCRIPTION
Returns amount of tokens in the read-side pipe (number of jobs that could be started).

Signed-off-by: Olof Johansson <olof@lixom.net>