### PR TITLE
Support `--jobserver-auth=fifo:/path/to/fifo` in `Client::from_env` on unix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,38 +3,16 @@ on: [push, pull_request]
 
 env:
   CARGO_UNSTABLE_SPARSE_REGISTRY: "true"
-  MAKE_VERSION: "4.4.1"
 
 jobs:
   test:
-    name: Test using make 4.4.1
+    name: Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta, nightly]
     steps:
-      - name: Cache make compiled
-      id: cache-make
-      uses: actions/cache@v3
-      with:
-        path: /usr/local/bin/make
-        key: ${{ runner.os }}-make-${{ env.MAKE_VERSION }}
-
-      # Compile it from source (temporarily)
-      - name: Make GNU Make from source
-        if: steps.cache-make.outputs.cache-hit != 'true'
-        run: |
-          curl "https://ftp.gnu.org/gnu/make/make-${MAKE_VERSION}.tar.gz" | tar x
-          pushd "make-${MAKE_VERSION}"
-          ./configure
-          make -j "$(nproc)"
-          popd
-          cp -rp "make-${MAKE_VERSION}/make" /usr/local/bin
-
-      - name: Verify that we are using make 4.4.1
-        run: make -v | grep "GNU Make ${MAKE_VERSION}"
-
       - uses: actions/checkout@v3
       - name: Install Rust
         run: |
@@ -52,3 +30,14 @@ jobs:
             target/
           key: cargo-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo test --all-features
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: |
+          rustup toolchain add nightly --no-self-update
+          rustup component add rustfmt --toolchain nightly
+      - run: cargo +nightly fmt -- --check

--- a/.github/workflows/make-4.4.yml
+++ b/.github/workflows/make-4.4.yml
@@ -28,7 +28,7 @@ jobs:
           curl "https://ftp.gnu.org/gnu/make/make-${MAKE_VERSION}.tar.gz" | tar xz
           pushd "make-${MAKE_VERSION}"
           ./configure
-          make -j "$(nproc)"
+          make
           popd
           cp -rp "make-${MAKE_VERSION}/make" /usr/local/bin
 

--- a/.github/workflows/make-4.4.yml
+++ b/.github/workflows/make-4.4.yml
@@ -15,11 +15,11 @@ jobs:
         rust: [stable, beta, nightly]
     steps:
       - name: Cache make compiled
-      id: cache-make
-      uses: actions/cache@v3
-      with:
-        path: /usr/local/bin/make
-        key: ${{ runner.os }}-make-${{ env.MAKE_VERSION }}
+        id: cache-make
+        uses: actions/cache@v3
+        with:
+          path: /usr/local/bin/make
+          key: ${{ runner.os }}-make-${{ env.MAKE_VERSION }}
 
       # Compile it from source (temporarily)
       - name: Make GNU Make from source

--- a/.github/workflows/make-4.4.yml
+++ b/.github/workflows/make-4.4.yml
@@ -1,4 +1,4 @@
-name: CI
+name: test make-4.4
 on: [push, pull_request]
 
 env:
@@ -6,7 +6,7 @@ env:
   MAKE_VERSION: "4.4.1"
 
 jobs:
-  test-make-4.4:
+  test:
     name: Test using make 4.4.1
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/make-4.4.yml
+++ b/.github/workflows/make-4.4.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Make GNU Make from source
         if: steps.cache-make.outputs.cache-hit != 'true'
         run: |
-          curl "https://ftp.gnu.org/gnu/make/make-${MAKE_VERSION}.tar.gz" | tar x
+          curl "https://ftp.gnu.org/gnu/make/make-${MAKE_VERSION}.tar.gz" | tar xz
           pushd "make-${MAKE_VERSION}"
           ./configure
           make -j "$(nproc)"

--- a/.github/workflows/make-4.4.yml
+++ b/.github/workflows/make-4.4.yml
@@ -6,7 +6,7 @@ env:
   MAKE_VERSION: "4.4.1"
 
 jobs:
-  test:
+  test-make-4.4:
     name: Test using make 4.4.1
     runs-on: ${{ matrix.os }}
     strategy:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,12 @@
 //! implemented with the `pipe` syscall and read/write ends of a pipe and on
 //! Windows this is implemented literally with IPC semaphores.
 //!
+//! Starting from GNU `make` version 4.4, named pipe becomes the default way
+//! in communication on Unix, which is supported by this crate.
+//!
+//! However, [`Client::configure_and_run`] and [`Client::configure_make_and_run`]
+//! still use the old syntax to keep backwards compatibility.
+//!
 //! The jobserver protocol in `make` also dictates when tokens are acquired to
 //! run child work, and clients using this crate should take care to implement
 //! such details to ensure correct interoperation with `make` itself.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -82,7 +82,7 @@ impl Client {
 
         if is_pipe_without_access_mode_check(file.as_raw_fd()) {
             // File in Rust is always closed-on-exec as long as it's opened by
-            // libstd itself.
+            // `File::open` or `fs::OpenOptions::open`.
             set_nonblocking(file.as_raw_fd(), true).ok()?;
 
             Some(Client {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -73,6 +73,7 @@ impl Client {
         }
     }
 
+    /// `--jobserver-auth=fifo:PATH`
     fn from_fifo(path: &Path) -> Option<Self> {
         let file = fs::OpenOptions::new()
             .read(true)
@@ -94,6 +95,7 @@ impl Client {
         }
     }
 
+    /// `--jobserver-auth=fd-for-R,fd-for-W`
     unsafe fn from_pipe(s: &str) -> Option<Self> {
         let (read, write) = s.split_once(',')?;
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -330,7 +330,6 @@ fn create_pipe(nonblocking: bool) -> io::Result<[RawFd; 2]> {
 
 fn set_cloexec(fd: c_int, set: bool) -> io::Result<()> {
     // F_GETFD/F_SETFD can only ret/set FD_CLOEXEC
-    //   which gives better performance on unix since it can use vfork.
     let flag = if set { libc::FD_CLOEXEC } else { 0 };
     cvt(unsafe { libc::fcntl(fd, libc::F_SETFD, flag) })?;
     Ok(())


### PR DESCRIPTION
This PR is ported from pull requests at upstream https://github.com/alexcrichton/jobserver-rs/pull/49 originally created by @weihanglo .

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>