### PR TITLE
Add new API for creating jobserver and run cmds with the named fifo on unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,16 @@ cfg-if = "1.0.0"
 tokio = { version = "1", default-features = false, features = ["process"], optional = true }
 scopeguard = "1.1.0"
 
-[target.'cfg(unix)'.dependencies]
-libc = "0.2.132"
-
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(any(unix, windows))'.dependencies]
 # Features: 
 #  - std: Implement std-only traits for getrandom::Error
 #  - rdrand: Enable fallback RDRAND-based implementation on x86/x86_64
 getrandom = { version = "0.2.7", features = ["std", "rdrand"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.132"
+
+[target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_System_WindowsProgramming", "Win32_System_Threading", "Win32_Foundation", "Win32_Security"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,12 @@
 //! in communication on Unix, which is supported by this crate.
 //!
 //! However, [`Client::configure_and_run`] and [`Client::configure_make_and_run`]
-//! still use the old syntax to keep backwards compatibility.
+//! still use the old syntax to keep backwards compatibility with existing
+//! programs, e.g. make < 4.4.
+//!
+//! To create a new fifo on unix, use [`Client::new_with_fifo`] and to use it
+//! for spawning process, use [`Client::configure_and_run_with_fifo`] or
+//! [`Client::configure_make_and_run_with_fifo`].
 //!
 //! The jobserver protocol in `make` also dictates when tokens are acquired to
 //! run child work, and clients using this crate should take care to implement
@@ -228,6 +233,28 @@ impl<T: Command> Command for &mut T {
     }
 }
 
+/// Returns RAII to ensure env_remove is called on unwinding
+fn setup_envs<'a, Cmd>(
+    mut cmd: Cmd,
+    envs: &'a [&'a str],
+    value: &ffi::OsStr,
+) -> ScopeGuard<Cmd, impl FnOnce(Cmd) + 'a>
+where
+    Cmd: Command,
+{
+    // Setup env
+    for env in envs {
+        cmd.env(env, value);
+    }
+
+    // Use RAII to ensure env_remove is called on unwinding
+    guard(cmd, move |mut cmd| {
+        for env in envs {
+            cmd.env_remove(env);
+        }
+    })
+}
+
 /// A client of a jobserver
 ///
 /// This structure is the main type exposed by this library, and is where
@@ -275,7 +302,9 @@ impl Client {
     }
 
     /// Same as [`Client::new`] except that it will create a named fifo on
-    /// unix so that you can use ....
+    /// unix so that you can use [`Client::configure_and_run_with_fifo`] or
+    /// [`Client::configure_make_and_run_with_fifo`] to pass the fifo
+    /// instead of fds.
     pub fn new_with_fifo(limit: usize) -> io::Result<Self> {
         #[cfg(unix)]
         {
@@ -406,31 +435,9 @@ impl Client {
         self.configure_and_run_inner(cmd, f, &["CARGO_MAKEFLAGS"])
     }
 
-    /// Configures a child process to have access to this client's jobserver as
-    /// well and run the `f` which spawns the process.
-    ///
-    /// NOTE that you have to spawn the process inside `f`, otherwise the jobserver
-    /// would not be inherited.
-    ///
-    /// This function is required to be called to ensure that a jobserver is
-    /// properly inherited to a child process. If this function is *not* called
-    /// then this `Client` will not be accessible in the child process. In other
-    /// words, if not called, then `Client::from_env` will return `None` in the
-    /// child process (or the equivalent of `Child::from_env` that `make` uses).
-    ///
-    /// ## Environment variables
-    ///
-    /// This function sets up `CARGO_MAKEFLAGS`, `MAKEFLAGS` and `MFLAGS`,
-    /// which is used by `cargo` and `make`.
-    ///
-    /// ## Platform-specific behavior
-    ///
-    /// On Unix and Windows this will clobber the `CARGO_MAKEFLAGS`,
-    /// `MAKEFLAGS` and `MFLAGS` environment variables for the child process,
-    /// and on Unix this will also allow the two file descriptors for
-    /// this client to be inherited to the child.
-    ///
-    /// On platforms other than Unix and Windows this panics.
+    /// Same as [`Client::configure_and_run`] except that it sets up environment
+    /// variables `CARGO_MAKEFLAGS`, `MAKEFLAGS` and `MFLAGS`, which is used by
+    /// `cargo` and `make`.
     pub fn configure_make_and_run<Cmd, F, R>(&self, cmd: Cmd, f: F) -> io::Result<R>
     where
         Cmd: Command,
@@ -454,19 +461,72 @@ impl Client {
         // both implementations.
         let value = format!("-j --jobserver-fds={0} --jobserver-auth={0}", arg);
 
-        // Setup env
-        for env in envs {
-            cmd.env(env, &value);
-        }
-
-        // Use RAII to ensure env_remove is called on unwinding
-        let mut cmd = guard(cmd, |mut cmd| {
-            for env in envs {
-                cmd.env_remove(env);
-            }
-        });
+        let mut cmd = setup_envs(cmd, envs, &ffi::OsStr::new(&value));
 
         f(&mut cmd)
+    }
+
+    /// Same as [`Client::configure_and_run`] except that it tries to pass
+    /// `--jobserver-auth=fifo:/path/to/fifo` to pass path to fifo instead of
+    /// fds and it does not pass `--jobserver-fds=r,w` and will fallback to
+    /// [`Client::configure_and_run`] if the client is not created using
+    /// [`Client::new_with_fifo`] or [`Client::from_env`] with
+    /// `CARGO_MAKEFLAGS`/`MAKEFLAGS`/`MFLAGS` containing
+    /// `--jobserver-auth=fifo:/path/to/fifo`.
+    ///
+    /// Using this function will break backwards compatibility for
+    /// some programs, e.g. make < `4.4`.
+    ///
+    /// Using this method does provide better performance since it doesn't need
+    /// to call [`Command::pre_run`] to register a callback to run in the new
+    /// process and thus can use vfork + exec for better performance.
+    pub fn configure_and_run_with_fifo<Cmd, F, R>(&self, cmd: Cmd, f: F) -> io::Result<R>
+    where
+        Cmd: Command,
+        F: FnOnce(&mut Cmd) -> io::Result<R>,
+    {
+        self.configure_and_run_with_fifo_inner(cmd, f, &["CARGO_MAKEFLAGS"])
+    }
+
+    /// Same as [`Client::configure_and_run_with_fifo`] except that it sets up
+    /// environment variables `CARGO_MAKEFLAGS`, `MAKEFLAGS` and `MFLAGS`,
+    /// which is used by `cargo` and `make`.
+    pub fn configure_make_and_run_with_fifo<Cmd, F, R>(&self, cmd: Cmd, f: F) -> io::Result<R>
+    where
+        Cmd: Command,
+        F: FnOnce(&mut Cmd) -> io::Result<R>,
+    {
+        self.configure_and_run_with_fifo_inner(cmd, f, &["CARGO_MAKEFLAGS", "MAKEFLAGS", "MFLAGS"])
+    }
+
+    fn configure_and_run_with_fifo_inner<Cmd, F, R>(
+        &self,
+        cmd: Cmd,
+        f: F,
+        envs: &[&str],
+    ) -> io::Result<R>
+    where
+        Cmd: Command,
+        F: FnOnce(&mut Cmd) -> io::Result<R>,
+    {
+        #[cfg(unix)]
+        {
+            if let Some(path) = self.inner.get_fifo() {
+                let path = path.as_os_str();
+
+                let prefix = "-j --jobserver-auth=";
+
+                let mut value = ffi::OsString::with_capacity(prefix.len() + path.len());
+                value.push(prefix);
+                value.push(path);
+
+                let mut cmd = setup_envs(cmd, envs, &value);
+
+                return f(&mut cmd);
+            }
+        }
+
+        self.configure_and_run_inner(cmd, f, envs)
     }
 
     /// Converts this `Client` into a helper thread to deal with a blocking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,7 @@ impl Client {
         // both implementations.
         let value = format!("-j --jobserver-fds={0} --jobserver-auth={0}", arg);
 
-        let mut cmd = setup_envs(cmd, envs, &ffi::OsStr::new(&value));
+        let mut cmd = setup_envs(cmd, envs, ffi::OsStr::new(&value));
 
         f(&mut cmd)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -468,11 +468,15 @@ impl Client {
 
     /// Same as [`Client::configure_and_run`] except that it tries to pass
     /// `--jobserver-auth=fifo:/path/to/fifo` to pass path to fifo instead of
-    /// fds and it does not pass `--jobserver-fds=r,w` and will fallback to
-    /// [`Client::configure_and_run`] if the client is not created using
-    /// [`Client::new_with_fifo`] or [`Client::from_env`] with
-    /// `CARGO_MAKEFLAGS`/`MAKEFLAGS`/`MFLAGS` containing
+    /// fds and it does not pass `--jobserver-fds=r,w` on unix and will
+    /// fallback to [`Client::configure_and_run`] if the client is not
+    /// created using [`Client::new_with_fifo`] or [`Client::from_env`]
+    /// with `CARGO_MAKEFLAGS`/`MAKEFLAGS`/`MFLAGS` containing
     /// `--jobserver-auth=fifo:/path/to/fifo`.
+    ///
+    /// On windows, [`Client`] always uses a named semaphore and on wasm,
+    /// such API is not supported since spawning processes is not supported
+    /// by wasm yet.
     ///
     /// Using this function will break backwards compatibility for
     /// some programs, e.g. make < `4.4`.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,9 +1,8 @@
-use libc::c_int;
-
 use std::{
     borrow::Cow,
     convert::TryInto,
     ffi::{OsStr, OsString},
+    fmt::Write as _,
     fs::{self, File},
     io::{self, Read, Write},
     mem::MaybeUninit,
@@ -11,13 +10,16 @@ use std::{
         ffi::{OsStrExt, OsStringExt},
         prelude::*,
     },
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
     thread::{Builder, JoinHandle},
 };
+
+use getrandom::getrandom;
+use libc::c_int;
 
 use crate::Command;
 
@@ -37,6 +39,10 @@ pub struct Client {
     read: File,
     /// This fd is set to be blocking
     write: File,
+    /// Path to the named fifo if any
+    path: Option<Box<Path>>,
+    /// If the Client owns the fifo, then we should remove it on drop.
+    owns_fifo: bool,
 }
 
 #[derive(Debug)]
@@ -45,12 +51,75 @@ pub struct Acquired {
 }
 
 impl Client {
-    pub fn new(mut limit: usize) -> io::Result<Client> {
+    pub fn new(limit: usize) -> io::Result<Self> {
         // Create nonblocking and cloexec pipes
         let pipes = create_pipe(true)?;
 
-        let client = unsafe { Client::from_fds(pipes[0], pipes[1]) };
+        let client = unsafe { Self::from_fds(pipes[0], pipes[1]) };
 
+        client.init(limit)?;
+
+        Ok(client)
+    }
+
+    pub fn new_fifo(limit: usize) -> io::Result<Self> {
+        // Try a bunch of random file name in /tmp until we get a unique one,
+        // but don't try for too long.
+        let prefix = "/tmp/__rust_jobslot_fifo_";
+
+        let mut name = prefix.to_string();
+        name.reserve(16);
+
+        for _ in 0..100 {
+            let mut bytes = [0; 16];
+            getrandom(&mut bytes)?;
+
+            write!(&mut name, "{}\0", u128::from_ne_bytes(bytes)).unwrap();
+
+            let res = cvt(unsafe {
+                libc::mkfifo(name.as_ptr() as *const _, libc::S_IRUSR | libc::S_IWUSR)
+            });
+
+            match res {
+                Ok(_) => {
+                    name.pop(); // chop off the trailing null
+                    let name = PathBuf::from(name);
+
+                    let file = open_file_rw(&name)?;
+
+                    // File in Rust is always closed-on-exec as long as it's opened by
+                    // `File::open` or `fs::OpenOptions::open`.
+                    set_nonblocking(file.as_raw_fd(), true)?;
+
+                    let client = Self {
+                        read: file.try_clone()?,
+                        write: file,
+                        path: Some(name.into_boxed_path()),
+                        owns_fifo: true,
+                    };
+
+                    client.init(limit)?;
+
+                    return Ok(client);
+                }
+                Err(err) => {
+                    if err.kind() == io::ErrorKind::AlreadyExists {
+                        name.truncate(prefix.len());
+                        continue;
+                    } else {
+                        return Err(err);
+                    }
+                }
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "failed to find a unique name for a semaphore",
+        ))
+    }
+
+    fn init(&self, mut limit: usize) -> io::Result<()> {
         // I don't think the character written here matters, but I could be
         // wrong!
         const BUFFER: [u8; 128] = [b'|'; 128];
@@ -61,14 +130,14 @@ impl Client {
             // Use nonblocking write here so that if the pipe
             // would block, then return err instead of blocking
             // the entire process forever.
-            (&client.write).write_all(&BUFFER[..n])?;
+            (&self.write).write_all(&BUFFER[..n])?;
             limit -= n;
         }
 
-        Ok(client)
+        Ok(())
     }
 
-    pub unsafe fn open(var: OsString) -> Option<Client> {
+    pub unsafe fn open(var: OsString) -> Option<Self> {
         let bytes = var.into_vec();
 
         let s = bytes
@@ -88,20 +157,18 @@ impl Client {
 
     /// `--jobserver-auth=fifo:PATH`
     fn from_fifo(path: &Path) -> Option<Self> {
-        let file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .ok()?;
+        let file = open_file_rw(path).ok()?;
 
         if is_pipe_without_access_mode_check(file.as_raw_fd()) {
             // File in Rust is always closed-on-exec as long as it's opened by
             // `File::open` or `fs::OpenOptions::open`.
             set_nonblocking(file.as_raw_fd(), true).ok()?;
 
-            Some(Client {
+            Some(Self {
                 read: file.try_clone().ok()?,
                 write: file,
+                path: Some(path.into()),
+                owns_fifo: false,
             })
         } else {
             None
@@ -130,16 +197,18 @@ impl Client {
             set_nonblocking(read, true).ok()?;
             set_nonblocking(write, true).ok()?;
 
-            Some(Client::from_fds(read, write))
+            Some(Self::from_fds(read, write))
         } else {
             None
         }
     }
 
-    unsafe fn from_fds(read: c_int, write: c_int) -> Client {
-        Client {
+    unsafe fn from_fds(read: c_int, write: c_int) -> Self {
+        Self {
             read: File::from_raw_fd(read),
             write: File::from_raw_fd(write),
+            path: None,
+            owns_fifo: false,
         }
     }
 
@@ -227,6 +296,16 @@ impl Client {
         let mut len = MaybeUninit::<c_int>::uninit();
         cvt(unsafe { libc::ioctl(self.read.as_raw_fd(), libc::FIONREAD, len.as_mut_ptr()) })?;
         Ok(unsafe { len.assume_init() }.try_into().unwrap())
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        if let Some(path) = &self.path {
+            if self.owns_fifo {
+                fs::remove_file(path).ok();
+            }
+        }
     }
 }
 
@@ -491,4 +570,8 @@ fn is_ready(revents: libc::c_short) -> io::Result<bool> {
         )),
         _ => Ok(false),
     }
+}
+
+fn open_file_rw(file: &Path) -> io::Result<File> {
+    fs::OpenOptions::new().read(true).write(true).open(file)
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -65,9 +65,6 @@ impl Client {
             limit -= n;
         }
 
-        // Set fd to be blocking
-        set_nonblocking(client.write.as_raw_fd(), false)?;
-
         Ok(client)
     }
 

--- a/tests/make-as-a-client-fifo.rs
+++ b/tests/make-as-a-client-fifo.rs
@@ -1,0 +1,77 @@
+use std::env;
+use std::fs::File;
+use std::io::prelude::*;
+use std::net::{TcpListener, TcpStream};
+use std::process::Command;
+
+use jobslot::Client;
+
+fn main() {
+    if env::var("_DO_THE_TEST").is_ok() {
+        std::process::exit(
+            Command::new(env::var_os("MAKE").unwrap())
+                .env("MAKEFLAGS", env::var_os("CARGO_MAKEFLAGS").unwrap())
+                .env_remove("_DO_THE_TEST")
+                .args(&env::args_os().skip(1).collect::<Vec<_>>())
+                .status()
+                .unwrap()
+                .code()
+                .unwrap_or(1),
+        );
+    }
+
+    if let Ok(s) = env::var("TEST_ADDR") {
+        let mut contents = Vec::new();
+        TcpStream::connect(s)
+            .unwrap()
+            .read_to_end(&mut contents)
+            .unwrap();
+        return;
+    }
+
+    let c = Client::new_with_fifo(1).unwrap();
+    let td = tempfile::tempdir().unwrap();
+
+    let prog = env::var("MAKE").unwrap_or_else(|_| "make".to_string());
+
+    let me = env::current_exe().unwrap();
+    let me = me.to_str().unwrap();
+
+    let mut cmd = Command::new(me);
+    cmd.current_dir(td.path());
+    cmd.env("MAKE", prog);
+    cmd.env("_DO_THE_TEST", "1");
+
+    File::create(td.path().join("Makefile"))
+        .unwrap()
+        .write_all(
+            format!(
+                "\
+all: foo bar
+foo:
+\t{0}
+bar:
+\t{0}
+",
+                me
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    cmd.env("TEST_ADDR", addr.to_string());
+
+    // We're leaking one extra token to `make` sort of violating the makefile
+    // jobserver protocol. It has the desired effect though.
+    let mut child = c.configure_and_run(&mut cmd, |cmd| cmd.spawn()).unwrap();
+
+    // We should get both connections as the two programs should be run
+    // concurrently.
+    let a = listener.accept().unwrap();
+    let b = listener.accept().unwrap();
+    drop((a, b));
+
+    assert!(child.wait().unwrap().success());
+}

--- a/tests/make-as-a-client-fifo.rs
+++ b/tests/make-as-a-client-fifo.rs
@@ -65,7 +65,9 @@ bar:
 
     // We're leaking one extra token to `make` sort of violating the makefile
     // jobserver protocol. It has the desired effect though.
-    let mut child = c.configure_and_run(&mut cmd, |cmd| cmd.spawn()).unwrap();
+    let mut child = c
+        .configure_make_and_run_with_fifo(&mut cmd, |cmd| cmd.spawn())
+        .unwrap();
 
     // We should get both connections as the two programs should be run
     // concurrently.

--- a/tests/make-as-a-client.rs
+++ b/tests/make-as-a-client.rs
@@ -65,7 +65,9 @@ bar:
 
     // We're leaking one extra token to `make` sort of violating the makefile
     // jobserver protocol. It has the desired effect though.
-    let mut child = c.configure_and_run(&mut cmd, |cmd| cmd.spawn()).unwrap();
+    let mut child = c
+        .configure_make_and_run(&mut cmd, |cmd| cmd.spawn())
+        .unwrap();
 
     // We should get both connections as the two programs should be run
     // concurrently.

--- a/tests/make-as-a-client.rs
+++ b/tests/make-as-a-client.rs
@@ -22,7 +22,7 @@ fn main() {
 
     if let Ok(s) = env::var("TEST_ADDR") {
         let mut contents = Vec::new();
-        TcpStream::connect(&s)
+        TcpStream::connect(s)
             .unwrap()
             .read_to_end(&mut contents)
             .unwrap();
@@ -37,7 +37,7 @@ fn main() {
     let me = env::current_exe().unwrap();
     let me = me.to_str().unwrap();
 
-    let mut cmd = Command::new(&me);
+    let mut cmd = Command::new(me);
     cmd.current_dir(td.path());
     cmd.env("MAKE", prog);
     cmd.env("_DO_THE_TEST", "1");


### PR DESCRIPTION
Fixed #36 

 - Add dep getrandom v0.2.7 for unix
 - Impl new fn `Client::new_with_fifo`
 - Fix `make-as-a-client` test: Use `Client::configure_make_and_run`
   so that `make` would actually load the jobserver and test it.
 - Impl `Client::configure_and_run_with_fifo`
 - Impl `Client::configure_make_and_run_with_fifo`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>