### PR TITLE
Use sccache for caching: Cache each crate separately

### DIFF
--- a/.github/actions/cache-setup/action.yml
+++ b/.github/actions/cache-setup/action.yml
@@ -1,0 +1,24 @@
+name: Setup cacheing
+
+runs:
+  using: composite
+  steps:
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: sccache
+    - name: Configure sccache
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+    - name: Export env for sccache to work
+      shell: bash
+      run: |
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+    - uses: webiny/action-post-run@3.0.0
+      id: post-run-command
+      with:
+        run: sccache --show-stats

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,28 @@
+name: Cleanup caches for closed PRs
+
+on:
+  # Run twice every day to remove the cache so that the caches from the closed prs
+  # are removed.
+  schedule:
+    - cron: "0 17 * * *"
+    - cron: "30 18 * * *"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+
+          export REPO="${{ github.repository }}"
+
+          gh pr list --state closed -L 20 --json number --jq '.[]|.number' | (
+              while IFS='$\n' read -r closed_pr; do
+                  BRANCH="refs/pull/${closed_pr}/merge" ./cleanup-cache.sh
+              done
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  CARGO_UNSTABLE_SPARSE_REGISTRY: "true"
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   test:
@@ -14,21 +14,15 @@ jobs:
         rust: [stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
+      - uses: ./.github/actions/cache-setup
+        env:
+          # cache-setup use binstall to install sccache,
+          # which works better when we provide it with GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust
         run: |
-          rustup toolchain add ${{ matrix.rust }} nightly --no-self-update
+          rustup toolchain add ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
-      - name: Generate Cargo.lock
-        run: cargo +nightly update
-      - name: Configure caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo test --all-features
 
   rustfmt:
@@ -38,6 +32,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: |
-          rustup toolchain add nightly --no-self-update
-          rustup component add rustfmt --toolchain nightly
+          rustup toolchain add nightly --no-self-update --component rustfmt
       - run: cargo +nightly fmt -- --check

--- a/.github/workflows/make-4.4.yml
+++ b/.github/workflows/make-4.4.yml
@@ -2,7 +2,7 @@ name: test make-4.4
 on: [push, pull_request]
 
 env:
-  CARGO_UNSTABLE_SPARSE_REGISTRY: "true"
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
   MAKE_VERSION: "4.4.1"
 
 jobs:
@@ -38,17 +38,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: |
-          rustup toolchain add ${{ matrix.rust }} nightly --no-self-update
+          rustup toolchain add ${{ matrix.rust }} --no-self-update
           rustup default ${{ matrix.rust }}
-      - name: Generate Cargo.lock
-        run: cargo +nightly update
-      - name: Configure caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ matrix.os }}-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: ./.github/actions/cache-setup
+        env:
+          # cache-setup use binstall to install sccache,
+          # which works better when we provide it with GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo test --all-features

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -2,7 +2,7 @@ name: msrv
 on: [push, pull_request]
 
 env:
-  CARGO_UNSTABLE_SPARSE_REGISTRY: "true"
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 
 jobs:
   test:
@@ -17,15 +17,9 @@ jobs:
         run: |
           rustup toolchain add 1.58 nightly --no-self-update
           rustup default 1.58
-      - name: Generate Cargo.lock
-        run: cargo +nightly update
-      - name: Configure caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ matrix.os }}-1.52-${{ hashFiles('**/Cargo.lock') }}
+      - uses: ./.github/actions/cache-setup
+        env:
+          # cache-setup use binstall to install sccache,
+          # which works better when we provide it with GITHUB_TOKEN.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo check --all-features

--- a/cleanup-cache.sh
+++ b/cleanup-cache.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -uxo pipefail
+
+REPO="${REPO?}"
+BRANCH="${BRANCH?}"
+
+while true; do
+    echo "Fetching list of cache key for $BRANCH"
+    cacheKeysForPR="$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f 1 )"
+
+    if [ -z "$cacheKeysForPR" ]; then
+        break
+    fi
+
+    ## Setting this to not fail the workflow while deleting cache keys. 
+    set +e
+    echo "Deleting caches..."
+    for cacheKey in $cacheKeysForPR
+    do
+        echo Removing "$cacheKey"
+        gh actions-cache delete "$cacheKey" -R "$REPO" -B "$BRANCH" --confirm
+    done
+done
+echo "Done cleaning up $BRANCH"


### PR DESCRIPTION
Instead of caching entire `/target` based on hash of `Cargo.lock`, which invalidates the entire cache if one of the dependency changed or a new version of jobslot is released.