### PR TITLE
Run `cargo-fmt` from stable channel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,5 +35,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Rust
         run: |
-          rustup toolchain add nightly --no-self-update --component rustfmt
-      - run: cargo +nightly fmt -- --check
+          rustup toolchain add stable --no-self-update --component rustfmt
+          rustup default stable
+      - run: cargo fmt -- --check


### PR DESCRIPTION
nightly channel might contain lint for unstable features or even conflict with advices given by `cargo-fmt` from stable channel.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>