### PR TITLE
Simplify unix implementation

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -412,7 +412,7 @@ fn create_pipe(nonblocking: bool) -> io::Result<[RawFd; 2]> {
     // with as many kernels/glibc implementations as possible.
     #[cfg(target_os = "linux")]
     {
-        use std::sync::{AtomicBool, Ordering::Relaxed};
+        use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 
         static PIPE2_AVAILABLE: AtomicBool = AtomicBool::new(true);
         if PIPE2_AVAILABLE.load(Relaxed) {


### PR DESCRIPTION
 - Remove second param of `set_nonblocking` since it is always set to `true`
 - Remove `is_pipe_without_access_mode_check`, change `is_pipe` to only take one parameter and add fn `get_access_mode` for checking access mode separately.
 - Use `ManuallyDrop::new(File::from_raw_fd(..))` to construct a `File` with no `Drop` so that we can call its `metadata()` and its `try_clone()` fn without having to implement them ourselves using `unsafe` code in `dup*`.
 - Fixed checking access mode of pipe fds: `O_RDWR` should also be accepted.