### PR TITLE
Optimize: Rm `pre_exec` call on `Command`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,6 +504,7 @@ impl Client {
         Cmd: Command,
         F: FnOnce(&mut Cmd) -> io::Result<R>,
     {
+        #[cfg(unix)]
         let arg = self.0.inner.string_arg();
         // Older implementations of make use `--jobserver-fds` and newer
         // implementations use `--jobserver-auth`, pass both to try to catch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,10 +504,6 @@ impl Client {
         Cmd: Command,
         F: FnOnce(&mut Cmd) -> io::Result<R>,
     {
-        // Register one-time callback on unix to unset CLO_EXEC
-        // in child process.
-        self.0.inner.pre_run(&mut cmd);
-
         let arg = self.0.inner.string_arg();
         // Older implementations of make use `--jobserver-fds` and newer
         // implementations use `--jobserver-auth`, pass both to try to catch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,6 +505,8 @@ impl Client {
         F: FnOnce(&mut Cmd) -> io::Result<R>,
     {
         #[cfg(unix)]
+        self.0.inner.pre_run(&mut cmd);
+
         let arg = self.0.inner.string_arg();
         // Older implementations of make use `--jobserver-fds` and newer
         // implementations use `--jobserver-auth`, pass both to try to catch

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -42,7 +42,8 @@ impl Client {
         // Create nonblocking and cloexec pipes
         let pipes = create_pipe()?;
 
-        let client = unsafe { Self::from_fds(pipes[0], pipes[1]) };
+        let mut client = unsafe { Self::from_fds(pipes[0], pipes[1]) };
+        client.owns = true;
 
         client.init(limit)?;
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -297,29 +297,6 @@ impl Client {
         }
     }
 
-    pub fn pre_run<Cmd>(&self, cmd: &mut Cmd)
-    where
-        Cmd: Command,
-    {
-        let read = self.read.as_raw_fd();
-        let write = self.write.as_raw_fd();
-
-        let mut fds = Some([read, write]);
-
-        let f = move || {
-            // Make sure this function is executed only once,
-            // so that the command may be reused with another
-            // Client.
-            for fd in fds.take().iter().flatten() {
-                set_cloexec(*fd, false)?;
-            }
-
-            Ok(())
-        };
-
-        unsafe { cmd.pre_exec(f) };
-    }
-
     pub fn available(&self) -> io::Result<usize> {
         let mut len = MaybeUninit::<c_int>::uninit();
         cvt(unsafe { libc::ioctl(self.read.as_raw_fd(), libc::FIONREAD, len.as_mut_ptr()) })?;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -13,6 +13,8 @@ use std::{
 use getrandom::getrandom;
 use libc::c_int;
 
+use crate::Command;
+
 #[derive(Debug)]
 enum ClientCreationArg {
     Fds { read: c_int, write: c_int },

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -98,13 +98,6 @@ impl Client {
         );
     }
 
-    pub fn pre_run<Cmd>(&self, _cmd: &mut Cmd) {
-        panic!(
-            "On this platform there is no cross process jobserver support,
-             so Client::configure_and_run is not supported."
-        );
-    }
-
     pub fn available(&self) -> io::Result<usize> {
         Ok(*self.count())
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -176,14 +176,6 @@ impl Client {
         Cow::Borrowed(&self.name)
     }
 
-    pub fn pre_run<Cmd>(&self, _cmd: &mut Cmd)
-    where
-        Cmd: Command,
-    {
-        // nothing to do here, we gave the name of our semaphore to the
-        // child above
-    }
-
     pub fn available(&self) -> io::Result<usize> {
         // Can't read value of a semaphore on Windows, so
         // try to acquire without sleeping, since we can find out the


### PR DESCRIPTION
On Unix `Client` created from env always clone the fds and now it also records the original fd used to construct the `Client` and pass it to children, there's no need to unset `CLOEXEC` before exec anymore.