### PR TITLE
fix: insert `fifo:` in `--jobserver-auth=fifo:/PATH`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,7 +570,7 @@ impl Client {
             if let Some(path) = self.0.inner.get_fifo() {
                 let path = path.as_os_str();
 
-                let prefix = "-j --jobserver-auth=";
+                let prefix = "-j --jobserver-auth=fifo:";
 
                 let mut value = ffi::OsString::with_capacity(prefix.len() + path.len());
                 value.push(prefix);


### PR DESCRIPTION
Seems like in fifo mode, jobslot missed inserting the `fifo::`.

That at least confuses ninja (which finally got at least jobserver client support, yay!):

```
ninja: warning: Ignoring jobserver: Semaphore mode is not supported on Posix! [-j --jobserver-auth=/tmp/GMfifo838583]
```

With this PR, it works with jobslot as server:

```
ninja: Jobserver mode detected: -j --jobserver-auth=fifo:/tmp/GMfifo839619
```

Both times [laze](https://github.com/kaspar030/laze) with experimental jobserver support, using jobslot to inherit from make, passing through to ninja.

Basically laze is doing `Client::from_env()` to get the jobserver from a parent make, and then calling ninja with `client.configure_make_and_run_with_fifo(...)`.